### PR TITLE
Reduce docker Image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,14 @@ FROM debian:buster-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
-
 # Set noninterative mode
 ENV DEBIAN_FRONTEND noninteractive
 
 ################## Update & upgrade ######################
 ENV PACKAGES wget mafft mcl libatlas-base-dev
 
-RUN apt-get update -y
-RUN apt-get install -y ${PACKAGES}
+RUN apt-get update -y && \
+  apt-get install -y ${PACKAGES}
 
 ################# Fastree install ########################
 ENV FASTTREE_URL http://www.microbesonline.org/fasttree/FastTree
@@ -36,7 +35,6 @@ RUN wget https://gite.lirmm.fr/atgc/FastME/-/archive/v${FASTME_VER}/FastME-v${FA
 ################# DIAMOND install ########################
 ENV DIAMOND_URL https://github.com/bbuchfink/diamond/releases/latest/download/diamond-linux64.tar.gz
 
-WORKDIR /opt
 RUN wget ${DIAMOND_URL} --no-check-certificate -O - | tar xvzf - && mv diamond /usr/local/bin/diamond
 
 ########################### orthoFinder install & run tests #############################
@@ -44,15 +42,14 @@ ENV ORTHOFINDER_FILE_NAME OrthoFinder.tar.gz
 ENV ORTHOFINDER_URL https://github.com/davidemms/OrthoFinder/releases/latest/download/${ORTHOFINDER_FILE_NAME}
 ENV ORTHOFINDER_PATH /opt/OrthoFinder
 
-WORKDIR /opt
-RUN wget ${ORTHOFINDER_URL} --no-check-certificate && tar -xvzf ${ORTHOFINDER_FILE_NAME}
-RUN ln -s ${ORTHOFINDER_PATH}/orthofinder /usr/local/bin/
-RUN ln -s ${ORTHOFINDER_PATH}/config.json /usr/local/bin/
-RUN rm -r ${ORTHOFINDER_PATH}/bin
+RUN wget ${ORTHOFINDER_URL} --no-check-certificate && tar -xvzf ${ORTHOFINDER_FILE_NAME} && \
+  ln -s ${ORTHOFINDER_PATH}/orthofinder /usr/local/bin/ && \
+  ln -s ${ORTHOFINDER_PATH}/config.json /usr/local/bin/ && \
+  rm -r ${ORTHOFINDER_PATH}/bin
 
 WORKDIR /root
-RUN pwd && ls -1
-RUN orthofinder -f ${ORTHOFINDER_PATH}/ExampleData/
+RUN pwd && ls -1 && \
+  orthofinder -f ${ORTHOFINDER_PATH}/ExampleData/
 
 ########################## clean source file #################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@
 # Based on cmonjeau/orthofinder (Monjeaud Cyril <Cyril.Monjeaud@irisa.fr>)
 ################################################
 
-FROM debian:buster
+FROM debian:buster-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/*
 
 
 # Set noninterative mode


### PR DESCRIPTION
Use debian:buster-slim as base image (reduces image size 591MB -> 535MB)
Reduce docker image layers (reduces image size 535MB -> 520MB)